### PR TITLE
feat: add info-token parser

### DIFF
--- a/src/reader.js
+++ b/src/reader.js
@@ -22,6 +22,7 @@ function nextToken(reader) {
     case 0xAA: return readErrorToken;
     case 0xAB: return readInfoErrorToken;
     case 0xAD: return readLoginAckToken;
+    case 0xA9: return readOrderToken;
     default:
       console.log(reader.buffer.slice(reader.position - 1));
       throw new Error('Unknown token type ' + type.toString(16));
@@ -125,3 +126,4 @@ const readColmetadataToken = require('./tokens/colmetadata/read');
 const readErrorToken = require('./tokens/error/read');
 const readInfoErrorToken = require('./tokens/infoerror/read');
 const readLoginAckToken = require('./tokens/loginack/read');
+const readOrderToken = require('./tokens/order/read');

--- a/src/reader.js
+++ b/src/reader.js
@@ -21,6 +21,7 @@ function nextToken(reader) {
     case 0x81: return readColmetadataToken;
     case 0xAA: return readErrorToken;
     case 0xAB: return readInfoErrorToken;
+    case 0xAD: return readLoginAckToken;
     default:
       console.log(reader.buffer.slice(reader.position - 1));
       throw new Error('Unknown token type ' + type.toString(16));
@@ -77,6 +78,10 @@ const Reader = module.exports = class Reader extends Transform {
     return this.buffer.readUInt32LE(this.position + offset);
   }
 
+  readUInt32BE(offset: number) : number {
+    return this.buffer.readUInt32BE(this.position + offset);
+  }
+
   readUInt64LE(offset: number) {
     // TODO: This can overflow
     return 4294967296 * this.buffer.readUInt32LE(this.position + 4) + this.buffer.readUInt32LE(this.position);
@@ -119,3 +124,4 @@ const readDoneInProcToken = require('./tokens/done-in-proc/read');
 const readColmetadataToken = require('./tokens/colmetadata/read');
 const readErrorToken = require('./tokens/error/read');
 const readInfoErrorToken = require('./tokens/infoerror/read');
+const readLoginAckToken = require('./tokens/loginack/read');

--- a/src/reader.js
+++ b/src/reader.js
@@ -20,6 +20,7 @@ function nextToken(reader) {
     case 0xFE: return readDoneProcToken;
     case 0x81: return readColmetadataToken;
     case 0xAA: return readErrorToken;
+    case 0xAB: return readInfoErrorToken;
     default:
       console.log(reader.buffer.slice(reader.position - 1));
       throw new Error('Unknown token type ' + type.toString(16));
@@ -85,7 +86,7 @@ const Reader = module.exports = class Reader extends Transform {
     if (!(chunk instanceof Buffer)) {
       return callback(new Error('Expected Buffer'));
     }
-
+   
     this.buffer = Buffer.concat([ this.buffer, chunk ]);
     this.position = 0;
 
@@ -105,7 +106,7 @@ const Reader = module.exports = class Reader extends Transform {
     if (this.bytesAvailable(1)) {
       return callback(new Error(`stream ended while waiting for data for '${this.next.name}'`));
     }
-
+    
     callback();
   }
 
@@ -117,3 +118,4 @@ const readDoneProcToken = require('./tokens/done-proc/read');
 const readDoneInProcToken = require('./tokens/done-in-proc/read');
 const readColmetadataToken = require('./tokens/colmetadata/read');
 const readErrorToken = require('./tokens/error/read');
+const readInfoErrorToken = require('./tokens/infoerror/read');

--- a/src/reader.js
+++ b/src/reader.js
@@ -86,7 +86,7 @@ const Reader = module.exports = class Reader extends Transform {
     if (!(chunk instanceof Buffer)) {
       return callback(new Error('Expected Buffer'));
     }
-   
+
     this.buffer = Buffer.concat([ this.buffer, chunk ]);
     this.position = 0;
 
@@ -106,7 +106,7 @@ const Reader = module.exports = class Reader extends Transform {
     if (this.bytesAvailable(1)) {
       return callback(new Error(`stream ended while waiting for data for '${this.next.name}'`));
     }
-    
+
     callback();
   }
 

--- a/src/reader.js
+++ b/src/reader.js
@@ -23,6 +23,7 @@ function nextToken(reader) {
     case 0xAB: return readInfoErrorToken;
     case 0xAD: return readLoginAckToken;
     case 0xA9: return readOrderToken;
+    case 0x79: return readReturnStatus;
     default:
       console.log(reader.buffer.slice(reader.position - 1));
       throw new Error('Unknown token type ' + type.toString(16));
@@ -79,6 +80,10 @@ const Reader = module.exports = class Reader extends Transform {
     return this.buffer.readUInt32LE(this.position + offset);
   }
 
+  readInt32LE(offset: number) : number {
+    return this.buffer.readInt32LE(this.position + offset);
+  }
+
   readUInt32BE(offset: number) : number {
     return this.buffer.readUInt32BE(this.position + offset);
   }
@@ -127,3 +132,4 @@ const readErrorToken = require('./tokens/error/read');
 const readInfoErrorToken = require('./tokens/infoerror/read');
 const readLoginAckToken = require('./tokens/loginack/read');
 const readOrderToken = require('./tokens/order/read');
+const readReturnStatus = require('./tokens/returnStatus/read');

--- a/src/tokens/infoerror/index.js
+++ b/src/tokens/infoerror/index.js
@@ -3,15 +3,15 @@
 const Token = require('../../token');
 
 class InfoErrorToken extends Token {
-    infoNumber: number
-    state: number
-    infoClass: number
-    message: string
-    serverName: string
-    procName: string
-    lineNumber: number
+  infoNumber: number
+  state: number
+  infoClass: number
+  message: string
+  serverName: string
+  procName: string
+  lineNumber: number
 
-    constructor(infoNumber: number,
+  constructor(infoNumber: number,
         state: number,
         infoClass: number,
         message: string,
@@ -19,15 +19,15 @@ class InfoErrorToken extends Token {
         procName: string,
         lineNumber: number) {
 
-        super(0xAB);
-        this.infoNumber = infoNumber;
-        this.state = state;
-        this.infoClass = infoClass;
-        this.message = message;
-        this.serverName = serverName;
-        this.procName = procName;
-        this.lineNumber = lineNumber;
-    }
+    super(0xAB);
+    this.infoNumber = infoNumber;
+    this.state = state;
+    this.infoClass = infoClass;
+    this.message = message;
+    this.serverName = serverName;
+    this.procName = procName;
+    this.lineNumber = lineNumber;
+  }
 }
 
 module.exports = InfoErrorToken;

--- a/src/tokens/infoerror/index.js
+++ b/src/tokens/infoerror/index.js
@@ -11,22 +11,16 @@ class InfoErrorToken extends Token {
   procName: string
   lineNumber: number
 
-  constructor(infoNumber: number,
-        state: number,
-        infoClass: number,
-        message: string,
-        serverName: string,
-        procName: string,
-        lineNumber: number) {
+  constructor() {
 
     super(0xAB);
-    this.infoNumber = infoNumber;
-    this.state = state;
-    this.infoClass = infoClass;
-    this.message = message;
-    this.serverName = serverName;
-    this.procName = procName;
-    this.lineNumber = lineNumber;
+    this.infoNumber = 0;
+    this.state = 0;
+    this.infoClass = 0;
+    this.message = '';
+    this.serverName = '';
+    this.procName = '';
+    this.lineNumber = 0;
   }
 }
 

--- a/src/tokens/infoerror/index.js
+++ b/src/tokens/infoerror/index.js
@@ -1,0 +1,35 @@
+/* @flow */
+
+const Token = require('../../token');
+
+class InfoErrorToken extends Token {
+    infoNumber: number
+    state: number
+    infoClass: number
+    message: string
+    serverName: string
+    procName: string
+    lineNumber: number
+
+    constructor(infoNumber: number,
+        state: number,
+        infoClass: number,
+        message: string,
+        serverName: string,
+        procName: string,
+        lineNumber: number) {
+
+        super(0xAB);
+        this.infoNumber = infoNumber;
+        this.state = state;
+        this.infoClass = infoClass;
+        this.message = message;
+        this.serverName = serverName;
+        this.procName = procName;
+        this.lineNumber = lineNumber;
+    }
+}
+
+module.exports = InfoErrorToken;
+
+InfoErrorToken.read = require('./read');

--- a/src/tokens/infoerror/read.js
+++ b/src/tokens/infoerror/read.js
@@ -3,56 +3,56 @@
 import type Reader from '../../reader';
 
 function readInfoErrorToken(reader: Reader) {
-    if (!reader.bytesAvailable(2)) {
-        return;
-    }
+  if (!reader.bytesAvailable(2)) {
+    return;
+  }
 
-    const length = reader.readUInt16LE(0);
+  const length = reader.readUInt16LE(0);
 
-    reader.consumeBytes(2);
-    if (!reader.bytesAvailable(length)) {
-        return;
-    }
+  reader.consumeBytes(2);
+  if (!reader.bytesAvailable(length)) {
+    return;
+  }
 
-    let offset = 0;
+  let offset = 0;
 
-    const infoNumber = reader.readUInt32LE(offset);
-    offset += 4;
+  const infoNumber = reader.readUInt32LE(offset);
+  offset += 4;
 
-    const state = reader.readUInt8(offset);
-    offset += 1;
+  const state = reader.readUInt8(offset);
+  offset += 1;
 
-    const infoClass = reader.readUInt8(offset);
-    offset += 1;
+  const infoClass = reader.readUInt8(offset);
+  offset += 1;
 
-    const messageLen = reader.readUInt16LE(offset) * 2;
+  const messageLen = reader.readUInt16LE(offset) * 2;
+  offset += 2;
+  const message = reader.readString('ucs2', offset, offset + messageLen);
+  offset += messageLen;
+
+  const serverNameLen = reader.readUInt8(offset) * 2;
+  offset += 1;
+  const serverName = reader.readString('ucs2', offset, offset + serverNameLen);
+  offset += serverNameLen;
+
+  const procNameLen = reader.readUInt8(offset) * 2;
+  offset += 1;
+  const procName = reader.readString('ucs2', offset, offset + procNameLen);
+  offset += procNameLen;
+
+  let lineNumber;
+  if (reader.version < 0x74000004) {
+    lineNumber = reader.readUInt16LE(offset);
     offset += 2;
-    const message = reader.readString('ucs2', offset, offset + messageLen);
-    offset += messageLen;
+  } else {
+    lineNumber = reader.readUInt32LE(offset);
+    offset += 4;
+  }
 
-    const serverNameLen = reader.readUInt8(offset) * 2;
-    offset += 1;
-    const serverName = reader.readString('ucs2', offset, offset + serverNameLen);
-    offset += serverNameLen;
+  reader.consumeBytes(offset);
 
-    const procNameLen = reader.readUInt8(offset) * 2;
-    offset += 1;
-    const procName = reader.readString('ucs2', offset, offset + procNameLen);
-    offset += procNameLen;
-
-    let lineNumber;
-    if (reader.version < 0x74000004) {
-        lineNumber = reader.readUInt16LE(offset);
-        offset += 2;
-    } else {
-        lineNumber = reader.readUInt32LE(offset);
-        offset += 4;
-    }
-
-    reader.consumeBytes(offset);
-
-    reader.push(new InfoErrorToken(infoNumber, state, infoClass, message, serverName, procName, lineNumber));
-    return reader.nextToken;
+  reader.push(new InfoErrorToken(infoNumber, state, infoClass, message, serverName, procName, lineNumber));
+  return reader.nextToken;
 }
 
 module.exports = readInfoErrorToken;

--- a/src/tokens/infoerror/read.js
+++ b/src/tokens/infoerror/read.js
@@ -15,43 +15,42 @@ function readInfoErrorToken(reader: Reader) {
   }
 
   let offset = 0;
-
-  const infoNumber = reader.readUInt32LE(offset);
+  const token = new InfoErrorToken();
+  token.infoNumber = reader.readUInt32LE(offset);
   offset += 4;
 
-  const state = reader.readUInt8(offset);
+  token.state = reader.readUInt8(offset);
   offset += 1;
 
-  const infoClass = reader.readUInt8(offset);
+  token.infoClass = reader.readUInt8(offset);
   offset += 1;
 
   const messageLen = reader.readUInt16LE(offset) * 2;
   offset += 2;
-  const message = reader.readString('ucs2', offset, offset + messageLen);
+  token.message = reader.readString('ucs2', offset, offset + messageLen);
   offset += messageLen;
 
   const serverNameLen = reader.readUInt8(offset) * 2;
   offset += 1;
-  const serverName = reader.readString('ucs2', offset, offset + serverNameLen);
+  token.serverName = reader.readString('ucs2', offset, offset + serverNameLen);
   offset += serverNameLen;
 
   const procNameLen = reader.readUInt8(offset) * 2;
   offset += 1;
-  const procName = reader.readString('ucs2', offset, offset + procNameLen);
+  token.procName = reader.readString('ucs2', offset, offset + procNameLen);
   offset += procNameLen;
 
-  let lineNumber;
   if (reader.version < 0x74000004) {
-    lineNumber = reader.readUInt16LE(offset);
+    token.lineNumber = reader.readUInt16LE(offset);
     offset += 2;
   } else {
-    lineNumber = reader.readUInt32LE(offset);
+    token.lineNumber = reader.readUInt32LE(offset);
     offset += 4;
   }
 
   reader.consumeBytes(offset);
 
-  reader.push(new InfoErrorToken(infoNumber, state, infoClass, message, serverName, procName, lineNumber));
+  reader.push(token);
   return reader.nextToken;
 }
 

--- a/src/tokens/infoerror/read.js
+++ b/src/tokens/infoerror/read.js
@@ -1,0 +1,60 @@
+/* @flow */
+
+import type Reader from '../../reader';
+
+function readInfoErrorToken(reader: Reader) {
+    if (!reader.bytesAvailable(2)) {
+        return;
+    }
+
+    const length = reader.readUInt16LE(0);
+
+    reader.consumeBytes(2);
+    if (!reader.bytesAvailable(length)) {
+        return;
+    }
+
+    let offset = 0;
+
+    const infoNumber = reader.readUInt32LE(offset);
+    offset += 4;
+
+    const state = reader.readUInt8(offset);
+    offset += 1;
+
+    const infoClass = reader.readUInt8(offset);
+    offset += 1;
+
+    const messageLen = reader.readUInt16LE(offset) * 2;
+    offset += 2;
+    const message = reader.readString('ucs2', offset, offset + messageLen);
+    offset += messageLen;
+
+    const serverNameLen = reader.readUInt8(offset) * 2;
+    offset += 1;
+    const serverName = reader.readString('ucs2', offset, offset + serverNameLen);
+    offset += serverNameLen;
+
+    const procNameLen = reader.readUInt8(offset) * 2;
+    offset += 1;
+    const procName = reader.readString('ucs2', offset, offset + procNameLen);
+    offset += procNameLen;
+
+    let lineNumber;
+    if (reader.version < 0x74000004) {
+        lineNumber = reader.readUInt16LE(offset);
+        offset += 2;
+    } else {
+        lineNumber = reader.readUInt32LE(offset);
+        offset += 4;
+    }
+
+    reader.consumeBytes(offset);
+
+    reader.push(new InfoErrorToken(infoNumber, state, infoClass, message, serverName, procName, lineNumber));
+    return reader.nextToken;
+}
+
+module.exports = readInfoErrorToken;
+
+const InfoErrorToken = require('.');

--- a/src/tokens/loginack/index.js
+++ b/src/tokens/loginack/index.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+const Token = require('../../token');
+
+class LoginAckToken extends Token {
+  length: number
+  interfaceNumber: number
+  tdsVersionNumber: number
+  progName: string
+  progVersion: {
+      major: number,
+      minor: number,
+      buildNumHi: number,
+      buildNumLow: number
+    }
+
+  constructor() {
+    super(0xAD);
+    this.length = 0;
+    this.interfaceNumber = 0;
+    this.tdsVersionNumber = 0;
+    this.progName = '';
+    this.progVersion = { major: 0, minor: 0, buildNumHi: 0, buildNumLow: 0 };
+  }
+}
+
+module.exports = LoginAckToken;
+
+LoginAckToken.read = require('./read');

--- a/src/tokens/loginack/read.js
+++ b/src/tokens/loginack/read.js
@@ -1,0 +1,46 @@
+/* @flow */
+
+import type Reader from '../../reader';
+
+function readLoginAckToken(reader: Reader) {
+  if (!reader.bytesAvailable(2)) {
+    return;
+  }
+
+  const length = reader.readUInt16LE(0);
+  reader.consumeBytes(2);
+  if (!reader.bytesAvailable(length)) {
+    return;
+  }
+
+  const token = new LoginAckToken();
+  let offset = 0;
+  token.interfaceNumber = reader.readUInt8(offset);
+  offset += 1;
+
+  token.tdsVersionNumber = reader.readUInt32BE(offset);
+  offset += 4;
+
+  const progNameLen = reader.readUInt8(offset) * 2;
+  offset += 1;
+  token.progName = reader.readString('ucs2', offset, offset + progNameLen);
+  offset += progNameLen;
+
+  token.progVersion.major = reader.readUInt8(offset);
+  offset += 1;
+  token.progVersion.minor = reader.readUInt8(offset);
+  offset += 1;
+  token.progVersion.buildNumHi = reader.readUInt8(offset);
+  offset += 1;
+  token.progVersion.buildNumLow = reader.readUInt8(offset);
+  offset += 1;
+  reader.consumeBytes(offset);
+
+  reader.push(token);
+
+  return reader.nextToken;
+}
+
+module.exports = readLoginAckToken;
+
+const LoginAckToken = require('.');

--- a/src/tokens/order/index.js
+++ b/src/tokens/order/index.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+const Token = require('../../token');
+
+class OrderToken extends Token {
+  columnCount: number
+  orderColumns: Array<number>
+
+  constructor(count: number) {
+    super(0xA9);
+    this.columnCount = count;
+    this.orderColumns = [];
+  }
+}
+
+module.exports = OrderToken;
+
+OrderToken.read = require('./read');

--- a/src/tokens/order/read.js
+++ b/src/tokens/order/read.js
@@ -1,0 +1,34 @@
+/* @flow */
+
+import type Reader from '../../reader';
+
+function readOrderToken(reader: Reader) {
+  if (!reader.bytesAvailable(2)) {
+    return;
+  }
+
+  const length = reader.readUInt16LE(0);
+  reader.consumeBytes(2);
+
+  const token = new OrderToken(length / 2);
+  reader.stash.push(token);
+  return parseColumnOrder;
+}
+
+function parseColumnOrder(reader: Reader) {
+  const token: OrderToken = reader.stash[reader.stash.length - 1];
+  if (token.columnCount == token.orderColumns.length) {
+    reader.push(token);
+    return reader.nextToken;
+  }
+
+  const colNumber = reader.readUInt16LE(0);
+  reader.consumeBytes(2);
+  token.orderColumns.push(colNumber);
+  reader.stash.push(token);
+  return parseColumnOrder;
+}
+
+module.exports = readOrderToken;
+
+const OrderToken = require('.');

--- a/src/tokens/returnStatus/index.js
+++ b/src/tokens/returnStatus/index.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+const Token = require('../../token');
+
+class ReturnStatusToken extends Token {
+  value: number
+
+  constructor(value: number) {
+    super(0x79);
+    this.value = value;
+  }
+}
+
+module.exports = ReturnStatusToken;
+
+ReturnStatusToken.read = require('./read');

--- a/src/tokens/returnStatus/read.js
+++ b/src/tokens/returnStatus/read.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+import type Reader from '../../reader';
+
+function readReturnStatus(reader: Reader) {
+  const value = reader.readInt32LE(0);
+  reader.consumeBytes(4);
+
+  reader.push(new ReturnStatusToken(value));
+  return reader.nextToken;
+}
+
+module.exports = readReturnStatus;
+
+const ReturnStatusToken = require('.');

--- a/test/infoError-test.js
+++ b/test/infoError-test.js
@@ -1,0 +1,151 @@
+/* @flow */
+
+const assert = require('chai').assert;
+const Reader = require('../src').Reader;
+const InfoErrorToken = require('../src/tokens/infoerror');
+
+
+describe('Parsing an INFO token', function () {
+    const encoding = 'ucs2';
+    describe('in TDS 7.4 mode', function () {
+        let reader;
+
+        beforeEach(function () {
+            reader = new Reader(0x74000004);
+        });
+
+        it('should parse the token correctly', function (done) {
+
+            const infoNumber = 3;
+            const state = 4;
+            const infoClass = 5;
+            const message = 'message';
+            const serverName = 'server';
+            const procName = 'proc';
+            const lineNumber = 6;
+
+            let buffer = Buffer.alloc(51);
+            let offset = 0;
+            buffer.writeUInt8(0xAB, offset);
+            offset = 1;
+            buffer.writeUInt16LE(48, offset);
+            offset += 2;
+            buffer.writeUInt32LE(infoNumber, offset);
+            offset += 4;
+            buffer.writeUInt8(state, offset);
+            offset += 1;
+            buffer.writeUInt8(infoClass, offset);
+            offset += 1;
+            buffer.writeUInt16LE(message.length, offset);
+            offset += 2;
+            buffer.write(message, offset, message.length * 2, encoding);
+            offset += Buffer.byteLength(message, encoding);
+            buffer.writeUInt8(serverName.length, offset);
+            offset += 1;
+            buffer.write(serverName, offset, serverName.length * 2, encoding);
+            offset += Buffer.byteLength(serverName, encoding);
+            buffer.writeUInt8(procName.length, offset);
+            offset += 1;
+            buffer.write(procName, offset, procName.length * 2, encoding);
+            offset += Buffer.byteLength(procName, encoding);
+            buffer.writeUInt32LE(lineNumber, offset);
+
+            let token;
+
+            reader.on('data', function (infoToken) {
+                var end = process.hrtime(start);
+                console.log("seconds elapsed = ", end);
+                assert.instanceOf(infoToken, InfoErrorToken);
+                token = infoToken;
+            });
+
+            reader.on('error', done);
+
+            reader.on('end', function () {
+                assert.strictEqual(token.infoNumber, infoNumber);
+                assert.strictEqual(token.state, state);
+                assert.strictEqual(token.infoClass, infoClass);
+                assert.strictEqual(token.message, message);
+                assert.strictEqual(token.serverName, serverName);
+                assert.strictEqual(token.procName, procName);
+                assert.strictEqual(token.lineNumber, lineNumber);
+
+                done();
+            });
+
+            const start = process.hrtime();
+            reader.end(buffer);
+        });
+    });
+
+    describe('in TDS 7.1 mode', function () {
+        let reader;
+
+        beforeEach(function () {
+            reader = new Reader(0x07010000);
+        });
+
+        it('should parse the token correctly', function (done) {
+
+            const infoNumber = 3;
+            const state = 4;
+            const infoClass = 5;
+            const message = 'message';
+            const serverName = 'server';
+            const procName = 'proc';
+            const lineNumber = 6;
+
+            let buffer = Buffer.alloc(49);
+            let offset = 0;
+            buffer.writeUInt8(0xAB, offset);
+            offset = 1;
+            buffer.writeUInt16LE(46, offset);
+            offset += 2;
+            buffer.writeUInt32LE(infoNumber, offset);
+            offset += 4;
+            buffer.writeUInt8(state, offset);
+            offset += 1;
+            buffer.writeUInt8(infoClass, offset);
+            offset += 1;
+            buffer.writeUInt16LE(message.length, offset);
+            offset += 2;
+            buffer.write(message, offset, message.length * 2, encoding);
+            offset += Buffer.byteLength(message, encoding);
+            buffer.writeUInt8(serverName.length, offset);
+            offset += 1;
+            buffer.write(serverName, offset, serverName.length * 2, encoding);
+            offset += Buffer.byteLength(serverName, encoding);
+            buffer.writeUInt8(procName.length, offset);
+            offset += 1;
+            buffer.write(procName, offset, procName.length * 2, encoding);
+            offset += Buffer.byteLength(procName, encoding);
+            buffer.writeUInt16LE(lineNumber, offset);
+
+            let token;
+
+            reader.on('data', function (infoToken) {
+                var end = process.hrtime(start);
+                console.log("seconds elapsed = ", end);
+                assert.instanceOf(infoToken, InfoErrorToken);
+                token = infoToken;
+            });
+
+            reader.on('error', done);
+
+            reader.on('end', function () {
+                assert.strictEqual(token.infoNumber, infoNumber);
+                assert.strictEqual(token.state, state);
+                assert.strictEqual(token.infoClass, infoClass);
+                assert.strictEqual(token.message, message);
+                assert.strictEqual(token.serverName, serverName);
+                assert.strictEqual(token.procName, procName);
+                assert.strictEqual(token.lineNumber, lineNumber);
+
+                done();
+            });
+
+            const start = process.hrtime();
+            reader.end(buffer);
+        });
+    });
+});

--- a/test/infoError-test.js
+++ b/test/infoError-test.js
@@ -5,147 +5,141 @@ const Reader = require('../src').Reader;
 const InfoErrorToken = require('../src/tokens/infoerror');
 
 
-describe('Parsing an INFO token', function () {
-    const encoding = 'ucs2';
-    describe('in TDS 7.4 mode', function () {
-        let reader;
+describe('Parsing an INFO token', function() {
+  const encoding = 'ucs2';
+  describe('in TDS 7.4 mode', function() {
+    let reader;
 
-        beforeEach(function () {
-            reader = new Reader(0x74000004);
-        });
-
-        it('should parse the token correctly', function (done) {
-
-            const infoNumber = 3;
-            const state = 4;
-            const infoClass = 5;
-            const message = 'message';
-            const serverName = 'server';
-            const procName = 'proc';
-            const lineNumber = 6;
-
-            let buffer = Buffer.alloc(51);
-            let offset = 0;
-            buffer.writeUInt8(0xAB, offset);
-            offset = 1;
-            buffer.writeUInt16LE(48, offset);
-            offset += 2;
-            buffer.writeUInt32LE(infoNumber, offset);
-            offset += 4;
-            buffer.writeUInt8(state, offset);
-            offset += 1;
-            buffer.writeUInt8(infoClass, offset);
-            offset += 1;
-            buffer.writeUInt16LE(message.length, offset);
-            offset += 2;
-            buffer.write(message, offset, message.length * 2, encoding);
-            offset += Buffer.byteLength(message, encoding);
-            buffer.writeUInt8(serverName.length, offset);
-            offset += 1;
-            buffer.write(serverName, offset, serverName.length * 2, encoding);
-            offset += Buffer.byteLength(serverName, encoding);
-            buffer.writeUInt8(procName.length, offset);
-            offset += 1;
-            buffer.write(procName, offset, procName.length * 2, encoding);
-            offset += Buffer.byteLength(procName, encoding);
-            buffer.writeUInt32LE(lineNumber, offset);
-
-            let token;
-
-            reader.on('data', function (infoToken) {
-                var end = process.hrtime(start);
-                console.log("seconds elapsed = ", end);
-                assert.instanceOf(infoToken, InfoErrorToken);
-                token = infoToken;
-            });
-
-            reader.on('error', done);
-
-            reader.on('end', function () {
-                assert.strictEqual(token.infoNumber, infoNumber);
-                assert.strictEqual(token.state, state);
-                assert.strictEqual(token.infoClass, infoClass);
-                assert.strictEqual(token.message, message);
-                assert.strictEqual(token.serverName, serverName);
-                assert.strictEqual(token.procName, procName);
-                assert.strictEqual(token.lineNumber, lineNumber);
-
-                done();
-            });
-
-            const start = process.hrtime();
-            reader.end(buffer);
-        });
+    beforeEach(function() {
+      reader = new Reader(0x74000004);
     });
 
-    describe('in TDS 7.1 mode', function () {
-        let reader;
+    it('should parse the token correctly', function(done) {
 
-        beforeEach(function () {
-            reader = new Reader(0x07010000);
-        });
+      const infoNumber = 3;
+      const state = 4;
+      const infoClass = 5;
+      const message = 'message';
+      const serverName = 'server';
+      const procName = 'proc';
+      const lineNumber = 6;
 
-        it('should parse the token correctly', function (done) {
+      const buffer = Buffer.alloc(51);
+      let offset = 0;
+      buffer.writeUInt8(0xAB, offset);
+      offset = 1;
+      buffer.writeUInt16LE(48, offset);
+      offset += 2;
+      buffer.writeUInt32LE(infoNumber, offset);
+      offset += 4;
+      buffer.writeUInt8(state, offset);
+      offset += 1;
+      buffer.writeUInt8(infoClass, offset);
+      offset += 1;
+      buffer.writeUInt16LE(message.length, offset);
+      offset += 2;
+      buffer.write(message, offset, message.length * 2, encoding);
+      offset += Buffer.byteLength(message, encoding);
+      buffer.writeUInt8(serverName.length, offset);
+      offset += 1;
+      buffer.write(serverName, offset, serverName.length * 2, encoding);
+      offset += Buffer.byteLength(serverName, encoding);
+      buffer.writeUInt8(procName.length, offset);
+      offset += 1;
+      buffer.write(procName, offset, procName.length * 2, encoding);
+      offset += Buffer.byteLength(procName, encoding);
+      buffer.writeUInt32LE(lineNumber, offset);
 
-            const infoNumber = 3;
-            const state = 4;
-            const infoClass = 5;
-            const message = 'message';
-            const serverName = 'server';
-            const procName = 'proc';
-            const lineNumber = 6;
+      let token;
 
-            let buffer = Buffer.alloc(49);
-            let offset = 0;
-            buffer.writeUInt8(0xAB, offset);
-            offset = 1;
-            buffer.writeUInt16LE(46, offset);
-            offset += 2;
-            buffer.writeUInt32LE(infoNumber, offset);
-            offset += 4;
-            buffer.writeUInt8(state, offset);
-            offset += 1;
-            buffer.writeUInt8(infoClass, offset);
-            offset += 1;
-            buffer.writeUInt16LE(message.length, offset);
-            offset += 2;
-            buffer.write(message, offset, message.length * 2, encoding);
-            offset += Buffer.byteLength(message, encoding);
-            buffer.writeUInt8(serverName.length, offset);
-            offset += 1;
-            buffer.write(serverName, offset, serverName.length * 2, encoding);
-            offset += Buffer.byteLength(serverName, encoding);
-            buffer.writeUInt8(procName.length, offset);
-            offset += 1;
-            buffer.write(procName, offset, procName.length * 2, encoding);
-            offset += Buffer.byteLength(procName, encoding);
-            buffer.writeUInt16LE(lineNumber, offset);
+      reader.on('data', function(infoToken) {
+        assert.instanceOf(infoToken, InfoErrorToken);
+        token = infoToken;
+      });
 
-            let token;
+      reader.on('error', done);
 
-            reader.on('data', function (infoToken) {
-                var end = process.hrtime(start);
-                console.log("seconds elapsed = ", end);
-                assert.instanceOf(infoToken, InfoErrorToken);
-                token = infoToken;
-            });
+      reader.on('end', function() {
+        assert.strictEqual(token.infoNumber, infoNumber);
+        assert.strictEqual(token.state, state);
+        assert.strictEqual(token.infoClass, infoClass);
+        assert.strictEqual(token.message, message);
+        assert.strictEqual(token.serverName, serverName);
+        assert.strictEqual(token.procName, procName);
+        assert.strictEqual(token.lineNumber, lineNumber);
 
-            reader.on('error', done);
+        done();
+      });
 
-            reader.on('end', function () {
-                assert.strictEqual(token.infoNumber, infoNumber);
-                assert.strictEqual(token.state, state);
-                assert.strictEqual(token.infoClass, infoClass);
-                assert.strictEqual(token.message, message);
-                assert.strictEqual(token.serverName, serverName);
-                assert.strictEqual(token.procName, procName);
-                assert.strictEqual(token.lineNumber, lineNumber);
-
-                done();
-            });
-
-            const start = process.hrtime();
-            reader.end(buffer);
-        });
+      reader.end(buffer);
     });
+  });
+
+  describe('in TDS 7.1 mode', function() {
+    let reader;
+
+    beforeEach(function() {
+      reader = new Reader(0x07010000);
+    });
+
+    it('should parse the token correctly', function(done) {
+
+      const infoNumber = 3;
+      const state = 4;
+      const infoClass = 5;
+      const message = 'message';
+      const serverName = 'server';
+      const procName = 'proc';
+      const lineNumber = 6;
+
+      const buffer = Buffer.alloc(49);
+      let offset = 0;
+      buffer.writeUInt8(0xAB, offset);
+      offset = 1;
+      buffer.writeUInt16LE(46, offset);
+      offset += 2;
+      buffer.writeUInt32LE(infoNumber, offset);
+      offset += 4;
+      buffer.writeUInt8(state, offset);
+      offset += 1;
+      buffer.writeUInt8(infoClass, offset);
+      offset += 1;
+      buffer.writeUInt16LE(message.length, offset);
+      offset += 2;
+      buffer.write(message, offset, message.length * 2, encoding);
+      offset += Buffer.byteLength(message, encoding);
+      buffer.writeUInt8(serverName.length, offset);
+      offset += 1;
+      buffer.write(serverName, offset, serverName.length * 2, encoding);
+      offset += Buffer.byteLength(serverName, encoding);
+      buffer.writeUInt8(procName.length, offset);
+      offset += 1;
+      buffer.write(procName, offset, procName.length * 2, encoding);
+      offset += Buffer.byteLength(procName, encoding);
+      buffer.writeUInt16LE(lineNumber, offset);
+
+      let token;
+
+      reader.on('data', function(infoToken) {
+        assert.instanceOf(infoToken, InfoErrorToken);
+        token = infoToken;
+      });
+
+      reader.on('error', done);
+
+      reader.on('end', function() {
+        assert.strictEqual(token.infoNumber, infoNumber);
+        assert.strictEqual(token.state, state);
+        assert.strictEqual(token.infoClass, infoClass);
+        assert.strictEqual(token.message, message);
+        assert.strictEqual(token.serverName, serverName);
+        assert.strictEqual(token.procName, procName);
+        assert.strictEqual(token.lineNumber, lineNumber);
+
+        done();
+      });
+
+      reader.end(buffer);
+    });
+  });
 });

--- a/test/loginAck-test.js
+++ b/test/loginAck-test.js
@@ -5,7 +5,7 @@ const Reader = require('../src').Reader;
 const LoginAckToken = require('../src/tokens/loginack');
 
 
-describe('Parsing an INFO token', function() {
+describe('Parsing an LOGINACK token', function() {
   const encoding = 'ucs2';
   let reader;
 

--- a/test/loginAck-test.js
+++ b/test/loginAck-test.js
@@ -1,0 +1,77 @@
+/* @flow */
+
+const assert = require('chai').assert;
+const Reader = require('../src').Reader;
+const LoginAckToken = require('../src/tokens/loginack');
+
+
+describe('Parsing an INFO token', function() {
+  const encoding = 'ucs2';
+  let reader;
+
+  beforeEach(function() {
+    reader = new Reader(0x74000004);
+  });
+
+  it('should parse the token correctly', function(done) {
+
+    var interfaceNumber = 1;
+    var tdsVersionNumber = 0x72090002;
+    var progName = 'prog';
+    var progVersion = {
+      major: 1,
+      minor: 2,
+      buildNumHi: 3,
+      buildNumLow: 4
+    };
+    const buffer = Buffer.alloc(21);
+    let offset = 0;
+    buffer.writeUInt8(0xAD, offset);
+    offset = 1;
+    buffer.writeUInt16LE(0, offset); // write length later
+    offset += 2;
+    buffer.writeUInt8(interfaceNumber, offset);
+    offset += 1;
+    buffer.writeUInt32BE(tdsVersionNumber, offset);
+    offset += 4;
+    buffer.writeUInt8(progName.length, offset);
+    offset += 1;
+    buffer.write(progName, offset, progName.length * 2, encoding);
+    offset += Buffer.byteLength(progName, encoding);
+    buffer.writeUInt8(progVersion.major, offset);
+    offset += 1;
+    buffer.writeUInt8(progVersion.minor, offset);
+    offset += 1;
+    buffer.writeUInt8(progVersion.buildNumHi, offset);
+    offset += 1;
+    buffer.writeUInt8(progVersion.buildNumLow, offset);
+    offset += 1;
+
+    // write length
+    buffer.writeUInt16LE(offset - 3, 1);
+    let token;
+
+    reader.on('data', function(loginAckToken) {
+      assert.instanceOf(loginAckToken, LoginAckToken);
+      token = loginAckToken;
+    });
+
+    reader.on('error', done);
+
+
+    reader.on('end', function() {
+      assert.strictEqual(token.interfaceNumber, interfaceNumber);
+      assert.strictEqual(token.tdsVersionNumber, tdsVersionNumber);
+      assert.strictEqual(token.progName, progName);
+      assert.strictEqual(token.progVersion.major, progVersion.major);
+      assert.strictEqual(token.progVersion.minor, progVersion.minor);
+      assert.strictEqual(token.progVersion.buildNumHi, progVersion.buildNumHi);
+      assert.strictEqual(token.progVersion.buildNumLow, progVersion.buildNumLow);
+
+      done();
+    });
+
+    reader.end(buffer);
+  });
+
+});

--- a/test/order-test.js
+++ b/test/order-test.js
@@ -1,0 +1,48 @@
+/* @flow */
+
+const assert = require('chai').assert;
+const Reader = require('../src').Reader;
+const OrderToken = require('../src/tokens/order');
+
+describe('Parsing a ORDER token', function() {
+  let reader, buffer;
+
+  beforeEach(function() {
+    reader = new Reader(0x74000004);
+    buffer = Buffer.alloc(7);
+  });
+
+  it('should parse the token correctly', function(done) {
+    const numberOfColumns = 2;
+    const length = numberOfColumns * 2;
+    const columns = [3, 6];
+
+    let offset = 0;
+    buffer.writeUInt8(0xA9, offset);
+    offset = 1;
+    buffer.writeUInt16LE(length, offset);
+    offset += 2;
+    buffer.writeUInt16LE(columns[0], offset);
+    offset += 2;
+    buffer.writeUInt16LE(columns[1], offset);
+    offset += 2;
+
+    let token;
+    reader.on('data', function(ordToken) {
+      assert.instanceOf(ordToken, OrderToken);
+      token = ordToken;
+    });
+
+    reader.on('error', done);
+
+    reader.on('end', function() {
+      assert.strictEqual(token.columnCount, numberOfColumns);
+      assert.strictEqual(token.orderColumns[0], columns[0]);
+      assert.strictEqual(token.orderColumns[1], columns[1]);
+
+      done();
+    });
+
+    reader.end(buffer);
+  });
+});

--- a/test/returnStatus.js
+++ b/test/returnStatus.js
@@ -1,0 +1,35 @@
+/* @flow */
+
+const assert = require('chai').assert;
+const Reader = require('../src').Reader;
+const ReturnStatusToken = require('../src/tokens/returnStatus');
+
+describe('Parsing a RETURNSTATUS token', function() {
+  let reader, buffer;
+
+  beforeEach(function() {
+    reader = new Reader(0x74000004);
+    buffer = Buffer.alloc(5);
+  });
+
+  it('should parse the token correctly', function(done) {
+    const returnValue = 56;
+
+    buffer.writeUInt8(0x79, 0);
+    buffer.writeInt32LE(returnValue, 1);
+    let token;
+    reader.on('data', function(statusToken) {
+      assert.instanceOf(statusToken, ReturnStatusToken);
+      token = statusToken;
+    });
+
+    reader.on('error', done);
+
+    reader.on('end', function() {
+      assert.strictEqual(token.value, returnValue);
+      done();
+    });
+
+    reader.end(buffer);
+  });
+});


### PR DESCRIPTION
@arthurschreiber this callback-less parser you have started is super fast 👏 

I'll start adding to this parser incrementally :)
I'm thinking of removing `consumeBytes` method in src/read.js, and update `this.position` in the `readXXX`, so we don't have to track offset in each token parser(just like the current tedious implementation). Before I go ahead and make changes, I want to make sure you dint have any specific reason for having them.