### PR TITLE
chore: update list of supported node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ notifications:
   email: false
 
 node_js:
-  - '4'
   - '6'
   - '8'
   - '9'
+  - '10'
 
 stages:
   - test


### PR DESCRIPTION
Node.js v4 is no longer supported, so let's drop it.